### PR TITLE
Fix user seed passwords

### DIFF
--- a/backend/src/seeds/user.seed.js
+++ b/backend/src/seeds/user.seed.js
@@ -1,6 +1,7 @@
 import { config } from "dotenv";
 import { connectDB } from "../lib/db.js";
 import User from "../models/user.model.js";
+import bcrypt from "bcryptjs";
 
 config();
 
@@ -104,7 +105,15 @@ const seedDatabase = async () => {
   try {
     await connectDB();
 
-    await User.insertMany(seedUsers);
+    // Hash passwords before inserting
+    const usersWithHashedPasswords = await Promise.all(
+      seedUsers.map(async (user) => ({
+        ...user,
+        password: await bcrypt.hash(user.password, 10),
+      }))
+    );
+
+    await User.insertMany(usersWithHashedPasswords);
     console.log("Database seeded successfully");
   } catch (error) {
     console.error("Error seeding database:", error);


### PR DESCRIPTION
## Summary
- hash passwords when running the user seeding script

## Testing
- `npm install --silent` *(fails: unable to reach registry)*

------
https://chatgpt.com/codex/tasks/task_e_6878009d46ac8331a93a6987542aa1c8